### PR TITLE
Merge master of activeadmin-translate into our one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # ActiveAdmin Translate Changelog
 
+## 0.2.7 - December 23, 2015
+
+- Fixed problem when block f.translate_inputs called before f.inputs and only one input field rendered (Thanks Pavel Borsky)
+
+## 0.2.6 - November 24, 2015
+
+- Support for has_many translates (Thanks Pavel Borsky)
+
 ## 0.2.5 - March 27, 2015
 
-Updates content_for block to accept record object (Thanks David Stump)
-Add more locales
+- Updates content_for block to accept record object (Thanks David Stump)
+- Add more locales
 
 ## 0.2.4 - January 14, 2015
 

--- a/lib/active_admin/translate/form_builder.rb
+++ b/lib/active_admin/translate/form_builder.rb
@@ -17,9 +17,14 @@ module ActiveAdmin
           html = "".html_safe
         end
 
+        template.assign(has_many_block: true)
+
         html << template.content_tag(:div, :class => "activeadmin-translate #{ translate_id }") do
           locale_tabs(available_locales) << locale_fields(name, available_locales, block) << tab_script
         end
+
+        template.concat(html) if template.output_buffer
+        html
       end
 
       protected
@@ -44,7 +49,7 @@ module ActiveAdmin
 
           fields = proc do |form|
             form.input(:locale, :as => :hidden)
-            block.call(form)
+            block.call form
           end
 
           inputs_for_nested_attributes(:for => [name, translation], :id => field_id(locale), :class => "inputs locale locale-#{ locale }", &fields)


### PR DESCRIPTION
This allows us to do
```
f.has_many :children do |t|
  t.translate_inputs :translations do |z|
    z.input :stuff
  end
end
```

which means that you can add translations for child nodes in a database.

PROPER JOB!!